### PR TITLE
Ad/init cmd

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: 'Run tests'
+on: [push]
+env:
+  GOPRIVATE: github.com/speakeasy-api/parser
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Test
+        run: |
+          git config --global url."https://${{ secrets.ACCESS_TOKEN }}@github.com/".insteadOf https://github.com/
+          cd cmd/speakeasy
+          go test

--- a/cmd/speakeasy/go.mod
+++ b/cmd/speakeasy/go.mod
@@ -1,4 +1,4 @@
-module main
+module cli
 
 go 1.17
 

--- a/cmd/speakeasy/main.go
+++ b/cmd/speakeasy/main.go
@@ -122,6 +122,7 @@ func initAction(c *cli.Context) error {
 		return fmt.Errorf("not supported %s propertyStrategy", strategy)
 	}
 
+	// apipackage library handles trimming white-space.
 	outputTypes := strings.Split(c.String(outputTypesFlag), ",")
 	if len(outputTypes) == 1 && len(outputTypes[0]) == 0 {
 		return fmt.Errorf("no output types specified")

--- a/cmd/speakeasy/main.go
+++ b/cmd/speakeasy/main.go
@@ -123,7 +123,7 @@ func initAction(c *cli.Context) error {
 	}
 
 	outputTypes := strings.Split(c.String(outputTypesFlag), ",")
-	if len(outputTypes) == 0 {
+	if len(outputTypes) == 1 && len(outputTypes[0]) == 0 {
 		return fmt.Errorf("no output types specified")
 	}
 

--- a/cmd/speakeasy/main_test.go
+++ b/cmd/speakeasy/main_test.go
@@ -13,6 +13,14 @@ import (
 const testOutputDirectory = ".testOutput"
 
 func TestInit(t *testing.T) {
+	defer func() {
+		// Clean up temporary output directory.
+		err := os.RemoveAll(testOutputDirectory)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
 	var tests = []struct {
 		strategy, outputTypes string
 		expected              string
@@ -20,6 +28,7 @@ func TestInit(t *testing.T) {
 		{parser.CamelCase, "json,yaml", ""},
 		{parser.SnakeCase, "json,yaml", ""},
 		{parser.PascalCase, "json,yaml", ""},
+		{parser.PascalCase, "json, yaml", ""},
 		{"invalidStrategy", "json,yaml", "not supported invalidStrategy propertyStrategy"},
 		{parser.CamelCase, "", "no output types specified"},
 	}
@@ -52,11 +61,5 @@ func TestInit(t *testing.T) {
 				t.Errorf("Got error with message %s, expected message %s", actual.Error(), test.expected)
 			}
 		})
-
-		// Clean up temporary output directory.
-		err := os.RemoveAll(testOutputDirectory)
-		if err != nil {
-			panic(err)
-		}
 	}
 }

--- a/cmd/speakeasy/main_test.go
+++ b/cmd/speakeasy/main_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/parser/services/parser"
+	"github.com/urfave/cli/v2"
+)
+
+const testOutputDirectory = ".testOutput"
+
+func TestInit(t *testing.T) {
+	var tests = []struct {
+		strategy, outputTypes string
+		expected              string
+	}{
+		{parser.CamelCase, "json,yaml", ""},
+		{parser.SnakeCase, "json,yaml", ""},
+		{parser.PascalCase, "json,yaml", ""},
+		{"invalidStrategy", "json,yaml", "not supported invalidStrategy propertyStrategy"},
+		{parser.CamelCase, "", "no output types specified"},
+	}
+
+	for _, test := range tests {
+
+		// Create temporary output directory.
+		if _, err := os.Stat(testOutputDirectory); os.IsNotExist(err) {
+			err := os.Mkdir(testOutputDirectory, os.ModePerm)
+			if err != nil {
+				panic(err)
+			}
+		}
+
+		t.Run(fmt.Sprintf("%s, %s", test.strategy, test.outputTypes), func(t *testing.T) {
+			set := flag.NewFlagSet("test", 0)
+			set.String(propertyStrategyFlag, test.strategy, "strategy")
+			set.String(outputTypesFlag, test.outputTypes, "outputTypes")
+			set.String(searchDirFlag, "test_fixtures", "search")
+			set.String(generalInfoFlag, "fixture.go", "generalInfo")
+			set.String(outputFlag, testOutputDirectory, "output")
+
+			actual := initAction(cli.NewContext(nil, set, nil))
+
+			if actual == nil {
+				if test.expected != "" {
+					t.Errorf("Got nil, expected error with message '%s'", test.expected)
+				}
+			} else if actual.Error() != test.expected {
+				t.Errorf("Got error with message %s, expected message %s", actual.Error(), test.expected)
+			}
+		})
+
+		// Clean up temporary output directory.
+		err := os.RemoveAll(testOutputDirectory)
+		if err != nil {
+			panic(err)
+		}
+	}
+}

--- a/cmd/speakeasy/test_fixtures/fixture.go
+++ b/cmd/speakeasy/test_fixtures/fixture.go
@@ -1,0 +1,34 @@
+package fixture
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type Item struct {
+	ItemID      string `json:"itemId" example:"A1B2C3"`
+	Description string `json:"description" example:"A random description"`
+	Quantity    int    `json:"quantity" example:"1"`
+}
+
+type Order struct {
+	OrderID      string    `json:"orderId" example:"1"`
+	CustomerName string    `json:"customerName" example:"Leo Messi"`
+	OrderedAt    time.Time `json:"orderedAt" example:"2019-11-09T21:21:46+00:00"`
+	Items        []Item    `json:"items"`
+}
+
+// CreateOrder godoc
+// @Success 200 {object} Order
+// @Router /orders [post]
+func createOrder(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var order Order
+	json.NewDecoder(r.Body).Decode(&order)
+	prevOrderID++
+	order.OrderID = strconv.Itoa(prevOrderID)
+	orders = append(orders, order)
+	json.NewEncoder(w).Encode(order)
+}


### PR DESCRIPTION
This fixes a logic error in the cli regarding an empty string being passed in with the `outputTypes` flag. 

The empty string is still present in the array returned from `strings.Split`, causing the `if` statement to never evaluate as true. The additional check will trigger the error in the event of an empty string.