### PR TITLE
Ad/init cmd build from config

### DIFF
--- a/cmd/speakeasy/build.go
+++ b/cmd/speakeasy/build.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/speakeasy-api/parser/apipackage"
+	"github.com/speakeasy-api/parser/services/parser"
+	"github.com/urfave/cli/v2"
+)
+
+var buildFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    generalInfoFlag,
+		Aliases: []string{"g"},
+		Value:   "main.go",
+		Usage:   "Go file path in which 'OpenAPI general API Info' is written",
+	},
+	&cli.StringFlag{
+		Name:    searchDirFlag,
+		Aliases: []string{"d"},
+		Value:   "./",
+		Usage:   "Directories you want to parse,comma separated and general-info file must be in the first one",
+	},
+	&cli.StringFlag{
+		Name:  excludeFlag,
+		Usage: "Exclude directories and files when searching, comma separated",
+	},
+	&cli.StringFlag{
+		Name:    propertyStrategyFlag,
+		Aliases: []string{"p"},
+		Value:   parser.CamelCase,
+		Usage:   "Property Naming Strategy like " + parser.SnakeCase + "," + parser.CamelCase + "," + parser.PascalCase,
+	},
+	&cli.StringFlag{
+		Name:    outputFlag,
+		Aliases: []string{"o"},
+		Value:   "./docs",
+		Usage:   "Output directory for all the generated files(opeanapi.json, opeanapi.yaml)",
+	},
+	&cli.StringFlag{
+		Name:    outputTypesFlag,
+		Aliases: []string{"ot"},
+		Value:   "json,yaml",
+		Usage:   "Output types of generated files (opeanapi.json, opeanapi.yaml) like go,json,yaml",
+	},
+	&cli.BoolFlag{
+		Name:  parseVendorFlag,
+		Usage: "Parse go files in 'vendor' folder, disabled by default",
+	},
+	&cli.BoolFlag{
+		Name:    parseDependencyFlag,
+		Aliases: []string{"pd"},
+		Usage:   "Parse go files inside dependency folder, disabled by default",
+	},
+	&cli.StringFlag{
+		Name:    markdownFilesFlag,
+		Aliases: []string{"md"},
+		Value:   "",
+		Usage:   "Parse folder containing markdown files to use as description, disabled by default",
+	},
+	&cli.StringFlag{
+		Name:    codeExampleFilesFlag,
+		Aliases: []string{"cef"},
+		Value:   "",
+		Usage:   "Parse folder containing code example files to use for the x-codeSamples extension, disabled by default",
+	},
+	&cli.BoolFlag{
+		Name:  parseInternalFlag,
+		Usage: "Parse go files in internal packages, disabled by default",
+	},
+	&cli.BoolFlag{
+		Name:  generatedTimeFlag,
+		Usage: "Generate timestamp at the top of docs.go, disabled by default",
+	},
+	&cli.IntFlag{
+		Name:  parseDepthFlag,
+		Value: 100,
+		Usage: "Dependency parse depth",
+	},
+	&cli.StringFlag{
+		Name:  instanceNameFlag,
+		Value: "",
+		Usage: "This parameter can be used to name different schema(openapi) document instances. It is optional.",
+	},
+	&cli.StringFlag{
+		Name:  overridesFileFlag,
+		Value: apipackage.DefaultOverridesFile,
+		Usage: "File to read global type overrides from.",
+	},
+}
+
+func buildAction(c *cli.Context) error {
+	strategy := c.String(propertyStrategyFlag)
+
+	switch strategy {
+	case parser.CamelCase, parser.SnakeCase, parser.PascalCase:
+	default:
+		return fmt.Errorf("not supported %s propertyStrategy", strategy)
+	}
+
+	// apipackage library handles trimming white-space.
+	outputTypes := strings.Split(c.String(outputTypesFlag), ",")
+	if len(outputTypes) == 1 && len(outputTypes[0]) == 0 {
+		return fmt.Errorf("no output types specified")
+	}
+
+	return apipackage.New().Build(&apipackage.Config{
+		SearchDir:           c.String(searchDirFlag),
+		Excludes:            c.String(excludeFlag),
+		MainAPIFile:         c.String(generalInfoFlag),
+		PropNamingStrategy:  strategy,
+		OutputDir:           c.String(outputFlag),
+		OutputTypes:         outputTypes,
+		ParseVendor:         c.Bool(parseVendorFlag),
+		ParseDependency:     c.Bool(parseDependencyFlag),
+		MarkdownFilesDir:    c.String(markdownFilesFlag),
+		ParseInternal:       c.Bool(parseInternalFlag),
+		GeneratedTime:       c.Bool(generatedTimeFlag),
+		CodeExampleFilesDir: c.String(codeExampleFilesFlag),
+		ParseDepth:          c.Int(parseDepthFlag),
+		InstanceName:        c.String(instanceNameFlag),
+		OverridesFile:       c.String(overridesFileFlag),
+	})
+}

--- a/cmd/speakeasy/build.go
+++ b/cmd/speakeasy/build.go
@@ -51,12 +51,6 @@ var buildFlags = []cli.Flag{
 		Usage:   "Output directory for all the generated files(opeanapi.json, opeanapi.yaml)",
 	},
 	&cli.StringFlag{
-		Name:    outputTypesFlag,
-		Aliases: []string{"ot"},
-		Value:   "json,yaml",
-		Usage:   "Output types of generated files (opeanapi.json, opeanapi.yaml) like go,json,yaml",
-	},
-	&cli.StringFlag{
 		Name:    configFileFlag,
 		Aliases: []string{"c"},
 		Value:   speakeasyConfigFileName,
@@ -122,7 +116,6 @@ func readConfig(fileName string) ([]SpeakeasyConfig, error) {
 	for decoder.Decode(&config) == nil {
 		configs = append(configs, config)
 	}
-	fmt.Printf("configs: %d\n\n", len(configs))
 	return configs, nil
 }
 

--- a/cmd/speakeasy/build.go
+++ b/cmd/speakeasy/build.go
@@ -155,7 +155,7 @@ func buildAction(c *cli.Context) error {
 			PropNamingStrategy: strategy,
 			// TODO: use the -o flag for the output dir and add property "OutputFile" to
 			// parser config to determine the output-file name.
-			OutputDir:           config.Name,
+			OutputDir:           fmt.Sprintf("schemas/%s", config.Name),
 			OutputTypes:         outputTypes,
 			ParseVendor:         c.Bool(parseVendorFlag),
 			ParseDependency:     c.Bool(parseDependencyFlag),

--- a/cmd/speakeasy/build_test.go
+++ b/cmd/speakeasy/build_test.go
@@ -12,7 +12,7 @@ import (
 
 const testOutputDirectory = ".testOutput"
 
-func TestInit(t *testing.T) {
+func TestBuild(t *testing.T) {
 	defer func() {
 		// Clean up temporary output directory.
 		err := os.RemoveAll(testOutputDirectory)

--- a/cmd/speakeasy/build_test.go
+++ b/cmd/speakeasy/build_test.go
@@ -15,11 +15,7 @@ const testOutputDirectory = ".buildTestOutput"
 func TestBuild(t *testing.T) {
 	defer func() {
 		// Clean up temporary output directories.
-		err := os.RemoveAll("another_api_name")
-		if err != nil {
-			panic(err)
-		}
-		err = os.RemoveAll("api_name")
+		err := os.RemoveAll("schemas")
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/speakeasy/build_test.go
+++ b/cmd/speakeasy/build_test.go
@@ -51,7 +51,7 @@ func TestInit(t *testing.T) {
 			set.String(generalInfoFlag, "fixture.go", "generalInfo")
 			set.String(outputFlag, testOutputDirectory, "output")
 
-			actual := initAction(cli.NewContext(nil, set, nil))
+			actual := buildAction(cli.NewContext(nil, set, nil))
 
 			if actual == nil {
 				if test.expected != "" {

--- a/cmd/speakeasy/build_test.go
+++ b/cmd/speakeasy/build_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-const testOutputDirectory = ".testOutput"
+const testOutputDirectory = ".buildTestOutput"
 
 func TestBuild(t *testing.T) {
 	defer func() {

--- a/cmd/speakeasy/init.go
+++ b/cmd/speakeasy/init.go
@@ -23,10 +23,9 @@ var initFlags = []cli.Flag{
 }
 
 const (
-	speakeasyFileName = "speakeasy.yaml"
-	actionFileName    = ".github/workflows/speakeasy.yaml"
-	apiNameVariable   = "SPEAKEASY_API_NAME"
-	apiRootVariable   = "SPEAKEASY_API_ROOT"
+	actionFileName  = ".github/workflows/speakeasy.yaml"
+	apiNameVariable = "SPEAKEASY_API_NAME"
+	apiRootVariable = "SPEAKEASY_API_ROOT"
 )
 
 func writeSliceToFile(stringsToWrite []string, fileName string) error {
@@ -63,21 +62,17 @@ func buildActionStrings() []string {
 	downloadString := "\t\t\t- name: Download Speakeasy\n\t\t\t\tuses: speakeasy-api/speakeasy-github-action\n"
 
 	// This builds and executes the speakeasy build command
-	runString := "\t\t- name: Setup and Update API state\n\t\t\trun: |"
-	// grep pulls the line, cut removes everything but the desired string, head -1 selects only the first result
-	apiNameString := fmt.Sprintf("\t\t\t\texport %s=$(grep -E -i '^name: ([^\n].*)' speakeasy.yaml | cut -d \" \" -f 2 | head -1)", apiNameVariable)
-	rootFileString := fmt.Sprintf("\t\t\t\texport %s=$(grep -E -i 'root: ([^\n].*)' speakeasy.yaml | cut -d \" \" -f 3 | head -1)", apiRootVariable)
-	commandString := fmt.Sprintf("\t\t\t\tspeakeasy build -n $%s -g $%s -o schemas/$%s\n", apiNameVariable, apiRootVariable, apiNameVariable)
+	runString := "\t\t- name: Setup and Update API state\n\t\t\trun: speakeasy build"
 
 	// The changes should be committed
 	commitString := "\t\t- name: Commit API state\n\t\t\trun: git add schemas; git commit -m \"[no ci]Add schema files\"; git push\n"
 
-	return []string{nameString, jobsString, containerString, stepsString, checkoutString, downloadString, runString, apiNameString, rootFileString, commandString, commitString}
+	return []string{nameString, jobsString, containerString, stepsString, checkoutString, downloadString, runString, commitString}
 }
 
 func initAction(c *cli.Context) error {
 	configStrings := buildConfigStrings(c)
-	err := writeSliceToFile(configStrings, speakeasyFileName)
+	err := writeSliceToFile(configStrings, speakeasyConfigFileName)
 	if err != nil {
 		return err
 	}

--- a/cmd/speakeasy/init.go
+++ b/cmd/speakeasy/init.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli/v2"
+)
+
+var initFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    generalInfoFlag,
+		Aliases: []string{"g"},
+		Value:   "main.go",
+		Usage:   "Go file path in which 'OpenAPI general API Info' is written",
+	},
+	&cli.StringFlag{
+		Name:    apiNameFlag,
+		Aliases: []string{"n"},
+		Value:   "main_api",
+		Usage:   "Name of the api",
+	},
+}
+
+const (
+	speakeasyFileName = "speakeasy.yaml"
+	actionFileName    = ".github/workflows/speakeasy.yaml"
+	apiNameVariable   = "SPEAKEASY_API_NAME"
+	apiRootVariable   = "SPEAKEASY_API_ROOT"
+)
+
+func writeSliceToFile(stringsToWrite []string, fileName string) error {
+	file, err := os.Create(fileName)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	for _, s := range stringsToWrite {
+		_, err = file.WriteString(fmt.Sprintf("%s\n", s))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildConfigStrings(c *cli.Context) []string {
+	nameString := fmt.Sprintf("name: %s", c.String(apiNameFlag))
+	versionString := "\tversion: v1"
+	openApiString := "\t\tOpenAPI3.0\n\t\tversion: 1.0.0"
+	rootString := fmt.Sprintf("\troot: %s", c.String(generalInfoFlag))
+	return []string{nameString, versionString, openApiString, rootString}
+}
+
+func buildActionStrings() []string {
+	// \n adds line of white-space
+	nameString := "name: Run Speakeasy CLI\n"
+	jobsString := "jobs:\n\tsetup_and_run_speakeasy:\n"
+	containerString := "\t\truns-on: ubuntu-latest\n\n\t\tpermissions:\n\t\t\tcontents: 'read'\n\t\t\tid-token: 'write'\n"
+	stepsString := "\t\tsteps:"
+	checkoutString := "\t\t\t- name: Checkout\n\t\t\t\tuses: actions/checkout@v3\n\t\t\t\twith:\n\t\t\t\t\tref: ${{ github.head_ref }}\n"
+	downloadString := "\t\t\t- name: Download Speakeasy\n\t\t\t\tuses: speakeasy-api/speakeasy-github-action\n"
+
+	// This builds and executes the speakeasy build command
+	runString := "\t\t- name: Setup and Update API state\n\t\t\trun: |"
+	// grep pulls the line, cut removes everything but the desired string, head -1 selects only the first result
+	apiNameString := fmt.Sprintf("\t\t\t\texport %s=$(grep -E -i '^name: ([^\n].*)' speakeasy.yaml | cut -d \" \" -f 2 | head -1)", apiNameVariable)
+	rootFileString := fmt.Sprintf("\t\t\t\texport %s=$(grep -E -i 'root: ([^\n].*)' speakeasy.yaml | cut -d \" \" -f 3 | head -1)", apiRootVariable)
+	commandString := fmt.Sprintf("\t\t\t\tspeakeasy build -n $%s -g $%s -o schemas/$%s\n", apiNameVariable, apiRootVariable, apiNameVariable)
+
+	// The changes should be committed
+	commitString := "\t\t- name: Commit API state\n\t\t\trun: git add schemas; git commit -m \"[no ci]Add schema files\"; git push\n"
+
+	return []string{nameString, jobsString, containerString, stepsString, checkoutString, downloadString, runString, apiNameString, rootFileString, commandString, commitString}
+}
+
+func initAction(c *cli.Context) error {
+	configStrings := buildConfigStrings(c)
+	err := writeSliceToFile(configStrings, speakeasyFileName)
+	if err != nil {
+		return err
+	}
+
+	buildActionStrings := buildActionStrings()
+	err = writeSliceToFile(buildActionStrings, actionFileName)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/speakeasy/init_test.go
+++ b/cmd/speakeasy/init_test.go
@@ -41,7 +41,7 @@ func TestBuildConfigStrings(t *testing.T) {
 }
 
 func TestBuildActionStrings(t *testing.T) {
-	expectedCount := 11
+	expectedCount := 8
 	t.Run("action string count", func(t *testing.T) {
 		actual := buildActionStrings()
 

--- a/cmd/speakeasy/init_test.go
+++ b/cmd/speakeasy/init_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+func TestBuildConfigStrings(t *testing.T) {
+	var tests = []struct {
+		name, generalInfo string
+		expected          []string
+	}{
+		{"api_name", "main.go", []string{"name: api_name", "\troot: main.go"}},
+		{"other_api", "controller.go", []string{"name: other_api", "\troot: controller.go"}},
+	}
+	expectedLength := 4
+
+	for _, test := range tests {
+
+		t.Run(fmt.Sprintf("%s, %s", test.name, test.generalInfo), func(t *testing.T) {
+			set := flag.NewFlagSet("test", 0)
+			set.String(apiNameFlag, test.name, "name")
+			set.String(generalInfoFlag, test.generalInfo, "generalInfo")
+
+			actual := buildConfigStrings(cli.NewContext(nil, set, nil))
+
+			if len(actual) != expectedLength {
+				t.Errorf("Receieved %d strings, expected %d", len(actual), expectedLength)
+			}
+			if actual[0] != test.expected[0] {
+				t.Errorf("Received %s, expected %s", actual[0], test.expected[0])
+			}
+			if actual[3] != test.expected[1] {
+				t.Errorf("Received %s, expected %s", actual[3], test.expected[1])
+			}
+		})
+	}
+}
+
+func TestBuildActionStrings(t *testing.T) {
+	expectedCount := 11
+	t.Run("action string count", func(t *testing.T) {
+		actual := buildActionStrings()
+
+		if len(actual) != expectedCount {
+			t.Errorf("Received %d strings, expected %d", len(actual), expectedCount)
+		}
+	})
+}

--- a/cmd/speakeasy/main.go
+++ b/cmd/speakeasy/main.go
@@ -13,6 +13,10 @@ import (
 )
 
 const (
+	speakeasyConfigFileName = "speakeasy.yaml"
+
+	// CLI flags
+	configFileFlag       = "config"
 	searchDirFlag        = "dir"
 	excludeFlag          = "exclude"
 	generalInfoFlag      = "generalInfo"

--- a/cmd/speakeasy/main.go
+++ b/cmd/speakeasy/main.go
@@ -28,6 +28,7 @@ const (
 	parseDepthFlag       = "parseDepth"
 	instanceNameFlag     = "instanceName"
 	overridesFileFlag    = "overridesFile"
+	apiNameFlag          = "apiNameFlag"
 )
 
 func exitNormally(diffEmpty bool) {
@@ -56,9 +57,16 @@ func main() {
 	app.Usage = "Automatically track the state of your API, Generate artifacts like OpenAPI schemas and more."
 	app.Commands = []*cli.Command{
 		{
-			Name:    "build",
+			Name:    "init",
 			Aliases: []string{"i"},
-			Usage:   "Create initial state and default schema artifacts",
+			Usage:   "Create initial state",
+			Action:  initAction,
+			Flags:   initFlags,
+		},
+		{
+			Name:    "build",
+			Aliases: []string{"b"},
+			Usage:   "Create schema artifacts",
 			Action:  buildAction,
 			Flags:   buildFlags,
 		},

--- a/cmd/speakeasy/main.go
+++ b/cmd/speakeasy/main.go
@@ -5,12 +5,10 @@ import (
 	"log"
 	"os"
 	"reflect"
-	"strings"
 
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v2"
 
-	"github.com/speakeasy-api/parser/apipackage"
 	"github.com/speakeasy-api/parser/services/parser"
 )
 
@@ -31,121 +29,6 @@ const (
 	instanceNameFlag     = "instanceName"
 	overridesFileFlag    = "overridesFile"
 )
-
-var initFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name:    generalInfoFlag,
-		Aliases: []string{"g"},
-		Value:   "main.go",
-		Usage:   "Go file path in which 'OpenAPI general API Info' is written",
-	},
-	&cli.StringFlag{
-		Name:    searchDirFlag,
-		Aliases: []string{"d"},
-		Value:   "./",
-		Usage:   "Directories you want to parse,comma separated and general-info file must be in the first one",
-	},
-	&cli.StringFlag{
-		Name:  excludeFlag,
-		Usage: "Exclude directories and files when searching, comma separated",
-	},
-	&cli.StringFlag{
-		Name:    propertyStrategyFlag,
-		Aliases: []string{"p"},
-		Value:   parser.CamelCase,
-		Usage:   "Property Naming Strategy like " + parser.SnakeCase + "," + parser.CamelCase + "," + parser.PascalCase,
-	},
-	&cli.StringFlag{
-		Name:    outputFlag,
-		Aliases: []string{"o"},
-		Value:   "./docs",
-		Usage:   "Output directory for all the generated files(opeanapi.json, opeanapi.yaml)",
-	},
-	&cli.StringFlag{
-		Name:    outputTypesFlag,
-		Aliases: []string{"ot"},
-		Value:   "json,yaml",
-		Usage:   "Output types of generated files (opeanapi.json, opeanapi.yaml) like go,json,yaml",
-	},
-	&cli.BoolFlag{
-		Name:  parseVendorFlag,
-		Usage: "Parse go files in 'vendor' folder, disabled by default",
-	},
-	&cli.BoolFlag{
-		Name:    parseDependencyFlag,
-		Aliases: []string{"pd"},
-		Usage:   "Parse go files inside dependency folder, disabled by default",
-	},
-	&cli.StringFlag{
-		Name:    markdownFilesFlag,
-		Aliases: []string{"md"},
-		Value:   "",
-		Usage:   "Parse folder containing markdown files to use as description, disabled by default",
-	},
-	&cli.StringFlag{
-		Name:    codeExampleFilesFlag,
-		Aliases: []string{"cef"},
-		Value:   "",
-		Usage:   "Parse folder containing code example files to use for the x-codeSamples extension, disabled by default",
-	},
-	&cli.BoolFlag{
-		Name:  parseInternalFlag,
-		Usage: "Parse go files in internal packages, disabled by default",
-	},
-	&cli.BoolFlag{
-		Name:  generatedTimeFlag,
-		Usage: "Generate timestamp at the top of docs.go, disabled by default",
-	},
-	&cli.IntFlag{
-		Name:  parseDepthFlag,
-		Value: 100,
-		Usage: "Dependency parse depth",
-	},
-	&cli.StringFlag{
-		Name:  instanceNameFlag,
-		Value: "",
-		Usage: "This parameter can be used to name different schema(openapi) document instances. It is optional.",
-	},
-	&cli.StringFlag{
-		Name:  overridesFileFlag,
-		Value: apipackage.DefaultOverridesFile,
-		Usage: "File to read global type overrides from.",
-	},
-}
-
-func initAction(c *cli.Context) error {
-	strategy := c.String(propertyStrategyFlag)
-
-	switch strategy {
-	case parser.CamelCase, parser.SnakeCase, parser.PascalCase:
-	default:
-		return fmt.Errorf("not supported %s propertyStrategy", strategy)
-	}
-
-	// apipackage library handles trimming white-space.
-	outputTypes := strings.Split(c.String(outputTypesFlag), ",")
-	if len(outputTypes) == 1 && len(outputTypes[0]) == 0 {
-		return fmt.Errorf("no output types specified")
-	}
-
-	return apipackage.New().Build(&apipackage.Config{
-		SearchDir:           c.String(searchDirFlag),
-		Excludes:            c.String(excludeFlag),
-		MainAPIFile:         c.String(generalInfoFlag),
-		PropNamingStrategy:  strategy,
-		OutputDir:           c.String(outputFlag),
-		OutputTypes:         outputTypes,
-		ParseVendor:         c.Bool(parseVendorFlag),
-		ParseDependency:     c.Bool(parseDependencyFlag),
-		MarkdownFilesDir:    c.String(markdownFilesFlag),
-		ParseInternal:       c.Bool(parseInternalFlag),
-		GeneratedTime:       c.Bool(generatedTimeFlag),
-		CodeExampleFilesDir: c.String(codeExampleFilesFlag),
-		ParseDepth:          c.Int(parseDepthFlag),
-		InstanceName:        c.String(instanceNameFlag),
-		OverridesFile:       c.String(overridesFileFlag),
-	})
-}
 
 func exitNormally(diffEmpty bool) {
 	if false && !diffEmpty {
@@ -173,11 +56,11 @@ func main() {
 	app.Usage = "Automatically track the state of your API, Generate artifacts like OpenAPI schemas and more."
 	app.Commands = []*cli.Command{
 		{
-			Name:    "init",
+			Name:    "build",
 			Aliases: []string{"i"},
 			Usage:   "Create initial state and default schema artifacts",
-			Action:  initAction,
-			Flags:   initFlags,
+			Action:  buildAction,
+			Flags:   buildFlags,
 		},
 		{
 			Name:    "fmt",

--- a/cmd/speakeasy/main.go
+++ b/cmd/speakeasy/main.go
@@ -22,7 +22,6 @@ const (
 	generalInfoFlag      = "generalInfo"
 	propertyStrategyFlag = "propertyStrategy"
 	outputFlag           = "output"
-	outputTypesFlag      = "outputTypes"
 	parseVendorFlag      = "parseVendor"
 	parseDependencyFlag  = "parseDependency"
 	markdownFilesFlag    = "markdownFiles"

--- a/cmd/speakeasy/test_fixtures/speakeasy.yaml
+++ b/cmd/speakeasy/test_fixtures/speakeasy.yaml
@@ -1,0 +1,17 @@
+name: api_name 
+spec:
+  version: v1 
+  schemas: 
+    type: OpenAPI3.0         
+    version: 1.0.0         
+    output: api_name.yaml,api_name.json
+root: fixture.go
+---
+name: another_api_name 
+spec: 
+  version: v1 
+  schemas: 
+    type: OpenAPI3.0         
+    version: 1.0.0         
+    output: another_api_name.yaml
+root: fixture.go  

--- a/cmd/speakeasy/test_fixtures/speakeasy_with_invalid_output.yaml
+++ b/cmd/speakeasy/test_fixtures/speakeasy_with_invalid_output.yaml
@@ -1,0 +1,8 @@
+name: api_name 
+spec:
+  version: v1 
+  Schemas: 
+    type: OpenAPI3.0         
+    version: 1.0.0         
+    output: api_name.txt
+root: fixture.go


### PR DESCRIPTION
This is an alternative to [this PR](https://github.com/speakeasy-api/cli/pull/26).

This changes the `speakeasy build` command to read from the config file some of the arguments it previously read from command-line arguments. An argument has been added for the `build` command that takes a filename to define _which_ yaml file to read the configs from (`speakeasy build -f configs/speakeasy.yaml`, for example).

It additionally required a change to the format of the `speakeasy.yaml` file so that it would be parsable by the yaml-parsing library.